### PR TITLE
Add authentication and calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # time-tracker
+
+This project implements a simple Toggl-like time tracker built with Ruby on Rails.
+
+## Setup
+
+1. Install Ruby 3.1.2 and run `bundle install` inside the `time-tracker` directory.
+2. Initialize the database with `bin/rails db:migrate`.
+3. Start the application with `bin/rails server` and visit `http://localhost:3000`.
+4. Sign up with your email and password, then use the calendar to track and comment on your hours.

--- a/time-tracker/Gemfile
+++ b/time-tracker/Gemfile
@@ -33,7 +33,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/time-tracker/README.md
+++ b/time-tracker/README.md
@@ -1,24 +1,11 @@
-# README
+# Time Tracker
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This Rails application is a minimal Toggl clone for tracking how long you spend on different tasks.
 
-Things you may want to cover:
+## Getting started
 
-* Ruby version
+1. Ensure Ruby 3.1.2 is available and run `bundle install`.
+2. Execute `bin/rails db:migrate` to set up the database.
+3. Start the server with `bin/rails server` and open `http://localhost:3000`.
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+Sign up with your email and password, then navigate the calendar to manage your tasks and time entries.

--- a/time-tracker/app/assets/stylesheets/application.css
+++ b/time-tracker/app/assets/stylesheets/application.css
@@ -13,3 +13,22 @@
  *= require_tree .
  *= require_self
  */
+body {
+  background-color: #121212;
+  color: #eee;
+  font-family: sans-serif;
+}
+
+a {
+  color: #81a1c1;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #333;
+  padding: 8px;
+}

--- a/time-tracker/app/controllers/application_controller.rb
+++ b/time-tracker/app/controllers/application_controller.rb
@@ -1,2 +1,13 @@
 class ApplicationController < ActionController::Base
+  helper_method :current_user
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+  end
+
+  def require_login
+    redirect_to new_session_path unless current_user
+  end
 end

--- a/time-tracker/app/controllers/calendar_controller.rb
+++ b/time-tracker/app/controllers/calendar_controller.rb
@@ -1,0 +1,8 @@
+class CalendarController < ApplicationController
+  before_action :require_login
+
+  def show
+    @date = params[:date] ? Date.parse(params[:date]) : Date.current
+    @tasks = current_user.tasks.includes(:time_entries)
+  end
+end

--- a/time-tracker/app/controllers/sessions_controller.rb
+++ b/time-tracker/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+
+  def new
+  end
+
+  def create
+    user = User.find_by(email: params[:email])
+    if user&.authenticate(params[:password])
+      session[:user_id] = user.id
+      redirect_to calendar_path
+    else
+      flash.now[:alert] = 'Invalid email or password'
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    session.delete(:user_id)
+    redirect_to new_session_path
+  end
+end

--- a/time-tracker/app/controllers/tasks_controller.rb
+++ b/time-tracker/app/controllers/tasks_controller.rb
@@ -1,0 +1,26 @@
+class TasksController < ApplicationController
+  before_action :require_login
+
+  def index
+    @tasks = current_user.tasks
+  end
+
+  def new
+    @task = current_user.tasks.build
+  end
+
+  def create
+    @task = current_user.tasks.build(task_params)
+    if @task.save
+      redirect_to tasks_path, notice: "Task created."
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def task_params
+    params.require(:task).permit(:name, :description)
+  end
+end

--- a/time-tracker/app/controllers/time_entries_controller.rb
+++ b/time-tracker/app/controllers/time_entries_controller.rb
@@ -1,0 +1,21 @@
+class TimeEntriesController < ApplicationController
+  before_action :require_login
+  before_action :set_task
+
+  def create
+    @time_entry = @task.time_entries.create(start_time: Time.current)
+    redirect_to calendar_path
+  end
+
+  def update
+    @time_entry = @task.time_entries.find(params[:id])
+    @time_entry.update(end_time: Time.current, comment: params[:time_entry][:comment])
+    redirect_to calendar_path
+  end
+
+  private
+
+  def set_task
+    @task = current_user.tasks.find(params[:task_id])
+  end
+end

--- a/time-tracker/app/controllers/users_controller.rb
+++ b/time-tracker/app/controllers/users_controller.rb
@@ -1,0 +1,21 @@
+class UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      redirect_to calendar_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password, :password_confirmation)
+  end
+end

--- a/time-tracker/app/models/task.rb
+++ b/time-tracker/app/models/task.rb
@@ -1,0 +1,8 @@
+class Task < ApplicationRecord
+  belongs_to :user
+  has_many :time_entries, dependent: :destroy
+
+  def running_time_entry
+    time_entries.find_by(end_time: nil)
+  end
+end

--- a/time-tracker/app/models/time_entry.rb
+++ b/time-tracker/app/models/time_entry.rb
@@ -1,0 +1,8 @@
+class TimeEntry < ApplicationRecord
+  belongs_to :task
+  delegate :user, to: :task
+
+  def duration
+    ((end_time || Time.current) - start_time).to_i
+  end
+end

--- a/time-tracker/app/models/user.rb
+++ b/time-tracker/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  has_secure_password
+  has_many :tasks, dependent: :destroy
+  has_many :time_entries, through: :tasks
+  validates :email, presence: true, uniqueness: true
+end

--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -1,0 +1,56 @@
+<h1>Calendar</h1>
+<p>
+  <%= link_to "Prev", calendar_path(date: (@date - 1.day).to_s) %> |
+  <%= link_to "Next", calendar_path(date: (@date + 1.day).to_s) %>
+</p>
+<h2><%= @date.strftime('%B %d, %Y') %></h2>
+<% total_seconds = 0 %>
+<% @tasks.each do |task| %>
+  <% total_seconds += task.time_entries.where(start_time: @date.beginning_of_day..@date.end_of_day).map(&:duration).sum %>
+<% end %>
+<p>Total: <%= Time.at(total_seconds).utc.strftime('%H:%M:%S') %></p>
+<table>
+  <thead>
+    <tr>
+      <th>Task</th>
+      <th>Duration (seconds)</th>
+      <th>Comment</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <% entries = task.time_entries.where(start_time: @date.beginning_of_day..@date.end_of_day) %>
+      <% entries.each do |entry| %>
+        <tr>
+          <td><%= task.name %></td>
+          <td><%= entry.duration %></td>
+          <td><%= entry.comment %></td>
+          <td></td>
+        </tr>
+      <% end %>
+      <% if task.running_time_entry %>
+        <% entry = task.running_time_entry %>
+        <tr>
+          <td><%= task.name %></td>
+          <td><%= entry.duration %></td>
+          <td>
+            <%= form_with model: [task, entry], method: :put do |f| %>
+              <%= f.text_field :comment, placeholder: "Comment" %>
+              <%= f.submit 'Stop' %>
+            <% end %>
+          </td>
+          <td></td>
+        </tr>
+      <% else %>
+        <tr>
+          <td><%= task.name %></td>
+          <td></td>
+          <td></td>
+          <td><%= button_to 'Start', task_time_entries_path(task), method: :post %></td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+<p><%= link_to 'Tasks', tasks_path %> | <%= link_to 'Logout', session_path, method: :delete %></p>

--- a/time-tracker/app/views/layouts/application.html.erb
+++ b/time-tracker/app/views/layouts/application.html.erb
@@ -11,6 +11,15 @@
   </head>
 
   <body>
+    <header>
+      <% if current_user %>
+        <nav>
+          <%= link_to 'Calendar', calendar_path %> |
+          <%= link_to 'Tasks', tasks_path %> |
+          <%= link_to 'Logout', session_path, method: :delete %>
+        </nav>
+      <% end %>
+    </header>
     <%= yield %>
   </body>
 </html>

--- a/time-tracker/app/views/sessions/new.html.erb
+++ b/time-tracker/app/views/sessions/new.html.erb
@@ -1,0 +1,13 @@
+<h1>Login</h1>
+<%= form_with url: session_path, method: :post do |f| %>
+  <p>
+    <%= f.label :email %><br>
+    <%= f.email_field :email %>
+  </p>
+  <p>
+    <%= f.label :password %><br>
+    <%= f.password_field :password %>
+  </p>
+  <%= f.submit 'Log in' %>
+<% end %>
+<p>New user? <%= link_to 'Sign up', new_user_path %></p>

--- a/time-tracker/app/views/tasks/index.html.erb
+++ b/time-tracker/app/views/tasks/index.html.erb
@@ -1,0 +1,33 @@
+<h1>Tasks</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= task.name %></td>
+        <td><%= task.description %></td>
+        <td>
+          <% if task.running_time_entry %>
+            <%= form_with model: [task, task.running_time_entry], method: :put do |f| %>
+              <%= f.text_field :comment, placeholder: "Comment" %>
+              <%= f.submit 'Stop' %>
+            <% end %>
+          <% else %>
+            <%= button_to 'Start', task_time_entries_path(task), method: :post %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to 'New Task', new_task_path %> |
+<%= link_to 'Calendar', calendar_path %> |
+<%= link_to 'Logout', session_path, method: :delete %>

--- a/time-tracker/app/views/tasks/new.html.erb
+++ b/time-tracker/app/views/tasks/new.html.erb
@@ -1,0 +1,16 @@
+<h1>New Task</h1>
+
+<%= form_with model: @task do |form| %>
+  <p>
+    <%= form.label :name %><br>
+    <%= form.text_field :name %>
+  </p>
+  <p>
+    <%= form.label :description %><br>
+    <%= form.text_area :description %>
+  </p>
+  <%= form.submit 'Create' %>
+<% end %>
+
+<%= link_to 'Back', tasks_path %> |
+<%= link_to 'Calendar', calendar_path %>

--- a/time-tracker/app/views/users/new.html.erb
+++ b/time-tracker/app/views/users/new.html.erb
@@ -1,0 +1,17 @@
+<h1>Sign Up</h1>
+<%= form_with model: @user do |f| %>
+  <p>
+    <%= f.label :email %><br>
+    <%= f.email_field :email %>
+  </p>
+  <p>
+    <%= f.label :password %><br>
+    <%= f.password_field :password %>
+  </p>
+  <p>
+    <%= f.label :password_confirmation %><br>
+    <%= f.password_field :password_confirmation %>
+  </p>
+  <%= f.submit 'Sign Up' %>
+<% end %>
+<p><%= link_to 'Login', new_session_path %></p>

--- a/time-tracker/config/routes.rb
+++ b/time-tracker/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  resource :session, only: %i[new create destroy]
+  resources :users, only: %i[new create]
+
+  resources :tasks, only: %i[index new create] do
+    resources :time_entries, only: %i[create update]
+  end
+
+  get 'calendar(/:date)', to: 'calendar#show', as: :calendar
+
+  root 'sessions#new'
 end

--- a/time-tracker/db/migrate/20240101000000_create_tasks.rb
+++ b/time-tracker/db/migrate/20240101000000_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tasks do |t|
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/time-tracker/db/migrate/20240101000001_create_time_entries.rb
+++ b/time-tracker/db/migrate/20240101000001_create_time_entries.rb
@@ -1,0 +1,11 @@
+class CreateTimeEntries < ActiveRecord::Migration[7.1]
+  def change
+    create_table :time_entries do |t|
+      t.references :task, null: false, foreign_key: true
+      t.datetime :start_time, null: false
+      t.datetime :end_time
+
+      t.timestamps
+    end
+  end
+end

--- a/time-tracker/db/migrate/20240101000002_create_users.rb
+++ b/time-tracker/db/migrate/20240101000002_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+    add_index :users, :email, unique: true
+  end
+end

--- a/time-tracker/db/migrate/20240101000003_add_comment_to_time_entries.rb
+++ b/time-tracker/db/migrate/20240101000003_add_comment_to_time_entries.rb
@@ -1,0 +1,5 @@
+class AddCommentToTimeEntries < ActiveRecord::Migration[7.1]
+  def change
+    add_column :time_entries, :comment, :string
+  end
+end

--- a/time-tracker/db/migrate/20240101000004_add_user_to_tasks.rb
+++ b/time-tracker/db/migrate/20240101000004_add_user_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserToTasks < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :tasks, :user, null: false, foreign_key: true
+  end
+end


### PR DESCRIPTION
## Summary
- enable bcrypt to support password authentication
- create User model with password and email
- implement Sessions and Calendar controllers
- secure controllers with login checks
- allow commenting on time entries
- add simple dark-mode styling
- document login setup in READMEs
- support per-user tasks with a signup page
- show total time per day on calendar

## Testing
- `bin/rails test` *(fails: rbenv: version `3.1.2` is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_684c1b7ca1b0832ab569ec1f6ef0e760