### PR TITLE
Improve edit form layout and add modal delete

### DIFF
--- a/time-tracker/app/javascript/controllers/modal_controller.js
+++ b/time-tracker/app/javascript/controllers/modal_controller.js
@@ -1,16 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["form"]
+  static values = { id: Number }
 
   open(event) {
-    event.preventDefault()
-    this.formTarget.action = event.currentTarget.dataset.url
+    this.idValue = event.currentTarget.dataset.modalIdValue
     this.element.classList.remove("hidden")
   }
 
-  cancel(event) {
-    event.preventDefault()
+  close() {
     this.element.classList.add("hidden")
+  }
+
+  confirm() {
+    fetch(`/time_entries/${this.idValue}`, {
+      method: "DELETE",
+      headers: { "Accept": "text/vnd.turbo-stream.html" }
+    })
+    .then(() => this.close())
   }
 }

--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -26,8 +26,12 @@
             <%= link_to edit_task_time_entry_path(entry.task, entry), class: 'icon-button', title: 'Edit' do %>
               <i class="fa fa-pen"></i> Edit
             <% end %>
-            <button data-action="modal#open" data-url="<%= task_time_entry_path(entry.task, entry) %>" class="icon-button" title="Delete">
-              <i class="fa fa-trash"></i> Delete
+            <button
+              data-action="click->modal#open"
+              data-modal-id-value="<%= entry.id %>"
+              class="text-red-600 hover:underline"
+            >
+              Delete
             </button>
           </td>
         </tr>

--- a/time-tracker/app/views/shared/_delete_modal.html.erb
+++ b/time-tracker/app/views/shared/_delete_modal.html.erb
@@ -1,13 +1,17 @@
-<div id="delete-modal" data-controller="modal" class="modal hidden">
-  <div class="bg-gray-800 p-4 rounded">
-    <p class="mb-4">Are you sure you want to delete?</p>
-    <div class="flex justify-end space-x-2">
-      <button data-action="modal#cancel" class="px-3 py-1 bg-gray-600 rounded">No</button>
-      <form data-modal-target="form" method="post">
-        <input type="hidden" name="_method" value="delete" />
-        <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
-        <button type="submit" class="px-3 py-1 bg-red-600 rounded">Yes</button>
-      </form>
+<div id="delete-modal" data-controller="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden">
+  <div class="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
+    <p class="mb-4 text-lg text-center">
+      Are you sure you want to delete this record?
+    </p>
+    <div class="flex justify-around">
+      <button
+        data-action="modal#confirm"
+        class="px-4 py-2 bg-red-600 text-white rounded-md"
+      >Yes</button>
+      <button
+        data-action="modal#close"
+        class="px-4 py-2 bg-gray-300 dark:bg-gray-600 rounded-md"
+      >No</button>
     </div>
   </div>
 </div>

--- a/time-tracker/app/views/tasks/edit.html.erb
+++ b/time-tracker/app/views/tasks/edit.html.erb
@@ -1,22 +1,24 @@
-<div class="max-w-md mx-auto mt-10 p-6 bg-gray-800 rounded text-white">
-  <h1 class="text-2xl mb-4 text-center">Edit Task</h1>
+<div class="min-h-screen flex flex-col items-center justify-center">
+  <h1 class="text-2xl mb-6">Edit Task</h1>
 
-  <%= form_with model: @task do |form| %>
-    <div class="mb-4">
-      <%= form.label :name, class: "block mb-1" %>
-      <%= form.text_field :name, class: "w-full" %>
+  <div class="max-w-lg w-full p-6 bg-white dark:bg-gray-800 rounded-xl shadow">
+    <%= form_with model: @task do |form| %>
+      <div class="mb-4">
+        <%= form.label :name, class: "block mb-1" %>
+        <%= form.text_field :name, class: "w-full" %>
+      </div>
+
+      <div class="mb-4">
+        <%= form.label :description, class: "block mb-1" %>
+        <%= form.text_area :description, rows: 3, class: "w-full" %>
+      </div>
+
+      <%= form.submit 'Update', class: "px-4 py-2 bg-green-600 rounded w-full" %>
+    <% end %>
+
+    <div class="mt-4 text-center">
+      <%= link_to 'Back', tasks_path %> |
+      <%= link_to 'Work Hours', calendar_path %>
     </div>
-
-    <div class="mb-4">
-      <%= form.label :description, class: "block mb-1" %>
-      <%= form.text_area :description, rows: 3, class: "w-full" %>
-    </div>
-
-    <%= form.submit 'Update', class: "px-4 py-2 bg-green-600 rounded w-full" %>
-  <% end %>
-
-  <div class="mt-4 text-center">
-    <%= link_to 'Back', tasks_path %> |
-    <%= link_to 'Work Hours', calendar_path %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- style the Edit Task page with centered card layout
- implement a Tailwind/Stimulus confirmation modal for deleting time entries
- update the Work Hours page to use the modal

## Testing
- `bin/rails test` *(fails: version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c50895b68832aa5a934a24b834565