### PR TITLE
Fix redirect after editing time entry

### DIFF
--- a/time-tracker/app/controllers/time_entries_controller.rb
+++ b/time-tracker/app/controllers/time_entries_controller.rb
@@ -29,7 +29,10 @@ class TimeEntriesController < ApplicationController
     @time_entry = @task.time_entries.find(params[:id])
     if params[:time_entry] && params[:time_entry].key?(:start_time)
       if @time_entry.update(time_entry_params)
-        redirect_to calendar_path(date: @time_entry.start_time.to_date, task_id: @task.id)
+        respond_to do |format|
+          format.html { redirect_to calendar_path(date: @time_entry.start_time.to_date, task_id: @task.id) }
+          format.json { head :no_content }
+        end
       else
         render :edit
       end

--- a/time-tracker/app/views/time_entries/edit.html.erb
+++ b/time-tracker/app/views/time_entries/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-md mx-auto mt-10 p-6 bg-gray-800 rounded text-white">
   <h1 class="text-2xl mb-4 text-center">Edit Time Entry for <%= @task.name %></h1>
 
-  <%= form_with model: [@task, @time_entry] do |f| %>
+  <%= form_with model: [@task, @time_entry], local: true do |f| %>
     <div class="mb-4">
       <%= f.label :start_time, class: "block mb-1" %>
       <%= f.datetime_local_field :start_time, class: "w-full" %>


### PR DESCRIPTION
## Summary
- make edit form submit without Turbo
- respond to HTML and JSON for time entry updates

## Testing
- `RBENV_VERSION=3.2.3 bundle exec rake test` *(fails: Gemfile requires Ruby 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_684c5498762c832a962ae611f68ea21e