### PR TITLE
Improve time entry deletion UX

### DIFF
--- a/time-tracker/app/controllers/time_entries_controller.rb
+++ b/time-tracker/app/controllers/time_entries_controller.rb
@@ -1,6 +1,7 @@
 class TimeEntriesController < ApplicationController
   before_action :require_login
-  before_action :set_task
+  before_action :set_task, except: :destroy
+  before_action :set_task_for_destroy, only: :destroy
 
   def new
     @time_entry = @task.time_entries.build
@@ -43,16 +44,23 @@ class TimeEntriesController < ApplicationController
   end
 
   def destroy
-    @time_entry = @task.time_entries.find(params[:id])
     date = @time_entry.start_time.to_date
     @time_entry.destroy
-    redirect_to calendar_path(date: date, task_id: @task.id)
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to calendar_path(date: date, task_id: @task.id) }
+    end
   end
 
   private
 
   def set_task
     @task = current_user.tasks.find(params[:task_id])
+  end
+
+  def set_task_for_destroy
+    @time_entry = current_user.time_entries.find(params[:id])
+    @task = @time_entry.task
   end
 
   def time_entry_params

--- a/time-tracker/app/javascript/controllers/delete_controller.js
+++ b/time-tracker/app/javascript/controllers/delete_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { id: Number }
+
+  confirm(event) {
+    this.idValue = event.currentTarget.dataset.deleteIdValue
+    this.element.classList.remove("hidden")
+  }
+
+  cancel() {
+    this.element.classList.add("hidden")
+  }
+
+  submit() {
+    fetch(`/time_entries/${this.idValue}`, {
+      method: "DELETE",
+      headers: { "Accept": "text/vnd.turbo-stream.html" }
+    }).then(() => this.cancel())
+  }
+}

--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -15,7 +15,7 @@
     </thead>
     <tbody>
       <% @time_entries.each do |entry| %>
-        <tr>
+        <tr id="time_entry_<%= entry.id %>">
           <td><%= entry.task.name %></td>
           <td><%= entry.start_time.in_time_zone('Asia/Tokyo').strftime('%A, %B %-d') %></td>
           <td><%= entry.start_time.in_time_zone('Asia/Tokyo').strftime('%H:%M') %></td>
@@ -27,8 +27,8 @@
               <i class="fa fa-pen"></i> Edit
             <% end %>
             <button
-              data-action="click->modal#open"
-              data-modal-id-value="<%= entry.id %>"
+              data-action="click->delete#confirm"
+              data-delete-id-value="<%= entry.id %>"
               class="text-red-600 hover:underline"
             >
               Delete
@@ -41,4 +41,16 @@
 
   <p><%= link_to 'Tasks', tasks_path %> | <%= link_to 'Logout', session_path, data: { turbo_method: :delete } %></p>
 </div>
-<%= render 'shared/delete_modal' %>
+<div
+  id="delete-modal"
+  class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden"
+  data-controller="delete"
+>
+  <div class="bg-white rounded-lg p-6 max-w-sm w-full">
+    <p class="text-lg text-center mb-4">Are you sure you want to delete this entry?</p>
+    <div class="flex justify-around">
+      <button class="bg-red-600 text-white px-4 py-2 rounded" data-action="click->delete#submit">Yes</button>
+      <button class="bg-gray-300 px-4 py-2 rounded" data-action="click->delete#cancel">No</button>
+    </div>
+  </div>
+</div>

--- a/time-tracker/app/views/time_entries/destroy.turbo_stream.erb
+++ b/time-tracker/app/views/time_entries/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "time_entry_#{@time_entry.id}" %>

--- a/time-tracker/config/routes.rb
+++ b/time-tracker/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
     resources :time_entries, except: %i[show]
   end
 
+  resources :time_entries, only: %i[destroy]
+
   get 'calendar(/:date)', to: 'calendar#show', as: :calendar
 
   root 'sessions#new'


### PR DESCRIPTION
## Summary
- update calendar view to use a Delete button wired to a modal
- add modal markup to `calendar/show` page
- implement a new Stimulus `delete` controller
- support Turbo deletion in controller and routes
- provide Turbo Stream template for removing deleted rows

## Testing
- `bin/rails test` *(fails: rbenv version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c5579da50832a8d711d15cc3dd18e