### PR TITLE
Fix task deletion modal

### DIFF
--- a/time-tracker/app/javascript/controllers/modal_controller.js
+++ b/time-tracker/app/javascript/controllers/modal_controller.js
@@ -13,9 +13,8 @@ export default class extends Controller {
   }
 
   confirm() {
-    fetch(`/time_entries/${this.idValue}`, {
-      method: "DELETE",
-      headers: { "Accept": "text/vnd.turbo-stream.html" }
+    fetch(`/tasks/${this.idValue}`, {
+      method: "DELETE"
     })
     .then(() => this.close())
   }

--- a/time-tracker/app/views/tasks/index.html.erb
+++ b/time-tracker/app/views/tasks/index.html.erb
@@ -35,7 +35,7 @@
           <%= link_to edit_task_path(task), class: 'icon-button', title: 'Edit' do %>
             <i class="fa fa-pen"></i>
           <% end %>
-          <button class="icon-button" data-action="modal#open" data-url="<%= task_path(task) %>">
+          <button class="icon-button" data-action="modal#open" data-modal-id-value="<%= task.id %>">
             <i class="fa fa-trash"></i>
           </button>
         </td>


### PR DESCRIPTION
## Summary
- fix the delete button on the tasks page
- update modal controller to send DELETE request to task path

## Testing
- `bundle exec rails test` *(fails: rbenv version `3.1.2` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c57aa5384832a8949888cca64171a