### PR TITLE
Fix delete modal targeting

### DIFF
--- a/time-tracker/app/javascript/controllers/delete_controller.js
+++ b/time-tracker/app/javascript/controllers/delete_controller.js
@@ -2,14 +2,15 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static values = { id: Number }
+  static targets = ["modal"]
 
   confirm(event) {
     this.idValue = event.currentTarget.dataset.deleteIdValue
-    this.element.classList.remove("hidden")
+    this.modalTarget.classList.remove("hidden")
   }
 
   cancel() {
-    this.element.classList.add("hidden")
+    this.modalTarget.classList.add("hidden")
   }
 
   submit() {

--- a/time-tracker/app/javascript/controllers/modal_controller.js
+++ b/time-tracker/app/javascript/controllers/modal_controller.js
@@ -2,20 +2,20 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static values = { id: Number }
+  static targets = ["modal"]
 
   open(event) {
     this.idValue = event.currentTarget.dataset.modalIdValue
-    this.element.classList.remove("hidden")
+    this.modalTarget.classList.remove("hidden")
   }
 
   close() {
-    this.element.classList.add("hidden")
+    this.modalTarget.classList.add("hidden")
   }
 
   confirm() {
-    fetch(`/time_entries/${this.idValue}`, {
-      method: "DELETE",
-      headers: { "Accept": "text/vnd.turbo-stream.html" }
+    fetch(`/tasks/${this.idValue}`, {
+      method: "DELETE"
     })
     .then(() => this.close())
   }

--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -1,3 +1,4 @@
+<div data-controller="delete">
 <div class="max-w-3xl mx-auto mt-8">
   <h1 class="text-2xl mb-4">Work Hours</h1>
 
@@ -44,7 +45,7 @@
 <div
   id="delete-modal"
   class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden"
-  data-controller="delete"
+  data-delete-target="modal"
 >
   <div class="bg-white rounded-lg p-6 max-w-sm w-full">
     <p class="text-lg text-center mb-4">Are you sure you want to delete this entry?</p>
@@ -53,4 +54,5 @@
       <button class="bg-gray-300 px-4 py-2 rounded" data-action="click->delete#cancel">No</button>
     </div>
   </div>
+</div>
 </div>

--- a/time-tracker/app/views/shared/_delete_modal.html.erb
+++ b/time-tracker/app/views/shared/_delete_modal.html.erb
@@ -1,4 +1,4 @@
-<div id="delete-modal" data-controller="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden">
+<div id="delete-modal" data-modal-target="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden">
   <div class="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
     <p class="mb-4 text-lg text-center">
       Are you sure you want to delete this record?

--- a/time-tracker/app/views/tasks/index.html.erb
+++ b/time-tracker/app/views/tasks/index.html.erb
@@ -1,3 +1,4 @@
+<div data-controller="modal">
 <div class="max-w-3xl mx-auto mt-8">
   <div data-controller="time-tracker" data-time-tracker-start="<%= current_running_entry&.start_time&.iso8601 %>" data-time-tracker-entry-id="<%= current_running_entry&.id %>" class="max-w-md mx-auto p-4 bg-gray-800 rounded text-white">
   <% if current_running_entry %>
@@ -35,7 +36,7 @@
           <%= link_to edit_task_path(task), class: 'icon-button', title: 'Edit' do %>
             <i class="fa fa-pen"></i>
           <% end %>
-          <button class="icon-button" data-action="modal#open" data-url="<%= task_path(task) %>">
+          <button class="icon-button" data-action="modal#open" data-modal-id-value="<%= task.id %>">
             <i class="fa fa-trash"></i>
           </button>
         </td>
@@ -50,5 +51,6 @@
   <%= link_to 'New Task', new_task_path %> |
   <%= link_to 'Work Hours', calendar_path %> |
   <%= link_to 'Logout', session_path, data: { turbo_method: :delete } %>
+</div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- make delete and modal controllers wrap surrounding content
- show and hide modals using targets so buttons outside can trigger them

## Testing
- `bundle exec rails test` *(fails: rbenv version `3.1.2` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c57aa5384832a8949888cca64171a