### PR TITLE
Fix task deletion and style modal

### DIFF
--- a/time-tracker/app/javascript/controllers/modal_controller.js
+++ b/time-tracker/app/javascript/controllers/modal_controller.js
@@ -15,8 +15,16 @@ export default class extends Controller {
 
   confirm() {
     fetch(`/tasks/${this.idValue}`, {
-      method: "DELETE"
+      method: "DELETE",
+      headers: {
+        'X-CSRF-Token': this.token(),
+        'Accept': 'text/html'
+      }
     })
-    .then(() => this.close())
+    .then(() => window.location.reload())
+  }
+
+  token() {
+    return document.querySelector('meta[name="csrf-token"]').content
   }
 }

--- a/time-tracker/app/views/shared/_delete_modal.html.erb
+++ b/time-tracker/app/views/shared/_delete_modal.html.erb
@@ -1,6 +1,6 @@
-<div id="delete-modal" data-modal-target="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden">
+<div id="delete-modal" data-modal-target="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 dark:bg-black/80 z-50 hidden">
   <div class="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
-    <p class="mb-4 text-lg text-center">
+    <p class="mb-4 text-lg text-center text-gray-900 dark:text-white">
       Are you sure you want to delete this record?
     </p>
     <div class="flex justify-around">
@@ -10,7 +10,7 @@
       >Yes</button>
       <button
         data-action="modal#close"
-        class="px-4 py-2 bg-gray-300 dark:bg-gray-600 rounded-md"
+        class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-black dark:text-white rounded-md"
       >No</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- style delete confirmation modal for dark mode
- include CSRF token and reload the page after deleting a task

## Testing
- `bundle exec rails test` *(fails: version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c5b7feb1c832a87bfc0e859f81a77