### PR TITLE
Fix calendar deletion

### DIFF
--- a/time-tracker/app/javascript/controllers/delete_controller.js
+++ b/time-tracker/app/javascript/controllers/delete_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
 
 export default class extends Controller {
   static values = { id: Number }
@@ -16,7 +17,17 @@ export default class extends Controller {
   submit() {
     fetch(`/time_entries/${this.idValue}`, {
       method: "DELETE",
-      headers: { "Accept": "text/vnd.turbo-stream.html" }
-    }).then(() => this.cancel())
+      headers: {
+        "Accept": "text/vnd.turbo-stream.html",
+        "X-CSRF-Token": this.token()
+      }
+    })
+      .then(response => response.text())
+      .then(html => Turbo.renderStreamMessage(html))
+      .then(() => this.cancel())
+  }
+
+  token() {
+    return document.querySelector('meta[name="csrf-token"]').content
   }
 }


### PR DESCRIPTION
## Summary
- render turbo response and send CSRF for calendar delete

## Testing
- `bundle exec rails test` *(fails: Ruby 3.1.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c5cbf2d58832ab824d4cced65f0bb