### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -2,7 +2,8 @@
 <div class="max-w-3xl mx-auto mt-8">
   <h1 class="text-2xl mb-4">Work Hours</h1>
 
-  <table class="mb-4">
+  <div class="overflow-x-auto">
+  <table class="mb-4 min-w-max">
     <thead>
       <tr>
         <th>Task</th>
@@ -39,6 +40,7 @@
       <% end %>
     </tbody>
   </table>
+  </div>
 
   <p><%= link_to 'Tasks', tasks_path %> | <%= link_to 'Logout', session_path, data: { turbo_method: :delete } %></p>
 </div>

--- a/time-tracker/app/views/layouts/application.html.erb
+++ b/time-tracker/app/views/layouts/application.html.erb
@@ -13,14 +13,14 @@
   </head>
 
   <body>
-    <header class="flex items-center justify-between">
+    <header class="flex flex-col sm:flex-row items-start sm:items-center justify-between p-2 gap-2">
       <% if current_user %>
         <div class="flex items-center space-x-2" id="header-controls" data-controller="header-timer" data-task-id="<%= current_running_entry&.task_id %>" data-entry-id="<%= current_running_entry&.id %>" data-start="<%= current_running_entry&.start_time&.iso8601 %>">
           <div id="timer" data-controller="timer" data-start="<%= current_running_entry&.start_time&.iso8601 %>">00:00:00.000</div>
           <button data-header-timer-target="startBtn" data-action="header-timer#start" class="icon-button" title="Start"><i class="fa fa-play"></i></button>
           <button data-header-timer-target="stopBtn" data-action="header-timer#stop" class="icon-button" title="Stop"><i class="fa fa-stop"></i></button>
         </div>
-        <nav>
+        <nav class="sm:ml-auto mt-2 sm:mt-0">
           <%= link_to 'Work Hours', calendar_path %> |
           <%= link_to 'Tasks', tasks_path %> |
           <%= link_to 'Logout', session_path, data: { turbo_method: :delete } %>

--- a/time-tracker/app/views/tasks/index.html.erb
+++ b/time-tracker/app/views/tasks/index.html.erb
@@ -19,7 +19,8 @@
   </div>
 
   <h2 class="mt-8">Tasks</h2>
-<table class="mt-2">
+  <div class="overflow-x-auto">
+<table class="mt-2 min-w-max">
   <thead>
     <tr>
       <th>Name</th>
@@ -44,6 +45,7 @@
     <% end %>
   </tbody>
 </table>
+  </div>
 
 <%= render 'shared/delete_modal' %>
 


### PR DESCRIPTION
## Summary
- make header layout stack vertically on small screens
- allow task and calendar tables to scroll on small screens

## Testing
- `bundle install --quiet` *(fails: Ruby 3.1.2 not installed)*
- `bin/rails test` *(fails: Ruby version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684c5f5d7678832ab0c4525fb1a96bd2