### PR TITLE
Add task picker modal for starting timer

### DIFF
--- a/time-tracker/app/javascript/controllers/header_timer_controller.js
+++ b/time-tracker/app/javascript/controllers/header_timer_controller.js
@@ -13,7 +13,8 @@ export default class extends Controller {
     event.preventDefault()
     const taskId = this.data.get("taskId")
     if (!taskId) {
-      window.location = "/tasks"
+      const modal = document.getElementById('task-picker')
+      if (modal) modal.classList.remove('hidden')
       return
     }
     fetch(`/tasks/${taskId}/time_entries`, {

--- a/time-tracker/app/javascript/controllers/picker_controller.js
+++ b/time-tracker/app/javascript/controllers/picker_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["task"]
+
+  confirm() {
+    const taskId = this.taskTarget.value
+    if (!taskId) return
+    fetch(`/tasks/${taskId}/time_entries`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'X-CSRF-Token': this.token()
+      }
+    })
+      .then(r => r.json())
+      .then(data => {
+        this.element.classList.add('hidden')
+        const header = document.getElementById('header-controls')
+        if (header) {
+          header.dataset.entryId = data.id
+          header.dataset.taskId = taskId
+          header.dataset.start = data.start_time
+          header.dispatchEvent(new Event('timer-start'))
+        }
+        const timer = document.getElementById('timer')
+        if (timer) timer.dataset.start = data.start_time
+      })
+  }
+
+  token() {
+    return document.querySelector('meta[name="csrf-token"]').content
+  }
+}

--- a/time-tracker/app/javascript/controllers/time_tracker_controller.js
+++ b/time-tracker/app/javascript/controllers/time_tracker_controller.js
@@ -26,7 +26,11 @@ export default class extends Controller {
   start(event) {
     event.preventDefault()
     const taskId = this.taskTarget.value
-    if (!taskId) return
+    if (!taskId) {
+      const modal = document.getElementById('task-picker')
+      if (modal) modal.classList.remove('hidden')
+      return
+    }
     this.startTime = new Date()
     this.startTicker(taskId)
     this.showStop()

--- a/time-tracker/app/javascript/controllers/timer_controller.js
+++ b/time-tracker/app/javascript/controllers/timer_controller.js
@@ -18,8 +18,10 @@ export default class extends Controller {
     const startAttr = this.element.dataset.start
     if (!startAttr) {
       this.element.textContent = "00:00:00.000"
+      this.element.classList.remove('animate-pulse')
       return
     }
+    this.element.classList.add('animate-pulse')
     const start = new Date(startAttr)
     const diff = Date.now() - start.getTime()
     const hours = Math.floor(diff / 3600000)

--- a/time-tracker/app/views/layouts/application.html.erb
+++ b/time-tracker/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <header class="flex flex-col sm:flex-row items-start sm:items-center justify-between p-2 gap-2">
       <% if current_user %>
         <div class="flex items-center space-x-2" id="header-controls" data-controller="header-timer" data-task-id="<%= current_running_entry&.task_id %>" data-entry-id="<%= current_running_entry&.id %>" data-start="<%= current_running_entry&.start_time&.iso8601 %>">
-          <div id="timer" data-controller="timer" data-start="<%= current_running_entry&.start_time&.iso8601 %>">00:00:00.000</div>
+          <div id="timer" class="text-5xl md:text-7xl font-mono" data-controller="timer" data-start="<%= current_running_entry&.start_time&.iso8601 %>">00:00:00.000</div>
           <button data-header-timer-target="startBtn" data-action="header-timer#start" class="icon-button" title="Start"><i class="fa fa-play"></i></button>
           <button data-header-timer-target="stopBtn" data-action="header-timer#stop" class="icon-button" title="Stop"><i class="fa fa-stop"></i></button>
         </div>
@@ -28,5 +28,6 @@
       <% end %>
     </header>
     <%= yield %>
+    <%= render 'shared/task_picker' %>
   </body>
 </html>

--- a/time-tracker/app/views/shared/_task_picker.html.erb
+++ b/time-tracker/app/views/shared/_task_picker.html.erb
@@ -1,0 +1,20 @@
+<div id="task-picker"
+     data-controller="picker"
+     class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+  <div class="bg-white p-6 rounded-xl w-full max-w-sm">
+    <h2 class="text-lg font-semibold mb-4 text-center">What are you working on?</h2>
+    <select data-picker-target="task" class="w-full mb-4">
+      <option value="">-- choose --</option>
+      <% Task.order(:name).each { |t| %>
+        <option value="<%= t.id %>"><%= t.name %></option>
+      <% } %>
+    </select>
+    <div class="flex gap-2">
+      <%= link_to '+ New task', new_task_path, class: 'underline text-sm flex-1' %>
+      <button data-action="picker#confirm"
+              class="flex-1 bg-indigo-600 text-white py-2 rounded-md">
+        Start
+      </button>
+    </div>
+  </div>
+</div>

--- a/time-tracker/db/seeds.rb
+++ b/time-tracker/db/seeds.rb
@@ -7,3 +7,7 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+User.find_each do |user|
+  user.tasks.find_or_create_by!(name: 'General')
+end


### PR DESCRIPTION
## Summary
- prompt for a task when starting the timer without one selected
- include shared task picker modal in layout
- add Picker stimulus controller
- style timer text and pulse while running
- seed a default `General` task for all users

## Testing
- `bundle exec rails test` *(fails: rbenv version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ccdfc2390832abc6406d9af16ad52