### PR TITLE
Fix root login redirect

### DIFF
--- a/time-tracker/config/routes.rb
+++ b/time-tracker/config/routes.rb
@@ -16,5 +16,5 @@ Rails.application.routes.draw do
 
   get 'calendar(/:date)', to: 'calendar#show', as: :calendar
 
-  root 'auth#new'
+  root 'tasks#index'
 end


### PR DESCRIPTION
## Summary
- redirect the root path to Tasks index

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684cd1985aa4832a9dfb322bc4956ac7