### PR TITLE
Fix Turbo login redirect

### DIFF
--- a/time-tracker/app/views/sessions/_form.html.erb
+++ b/time-tracker/app/views/sessions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: session_path, method: :post do |f| %>
+<%= form_with url: session_path, method: :post, data: { turbo_frame: "_top" } do |f| %>
   <div class="mb-4">
     <%= f.label :email, class: 'block mb-1' %>
     <%= f.email_field :email, class: 'w-full' %>

--- a/time-tracker/app/views/users/_form.html.erb
+++ b/time-tracker/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: user, url: users_path do |f| %>
+<%= form_with model: user, url: users_path, data: { turbo_frame: "_top" } do |f| %>
   <div class="mb-4">
     <%= f.label :email, class: 'block mb-1' %>
     <%= f.email_field :email, class: 'w-full' %>


### PR DESCRIPTION
## Summary
- fix Turbo redirect after login or signup by submitting outside the auth frame

## Testing
- `bundle exec rake test` *(fails: version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cd4776518832a831e59e2199cd3e7