### PR TITLE
Improve auth form dark styling

### DIFF
--- a/time-tracker/app/views/auth/_card.html.erb
+++ b/time-tracker/app/views/auth/_card.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-md mx-auto mt-24 p-8 bg-white rounded-xl shadow-lg" data-controller="auth" data-auth-login-url-value="<%= auth_form_path(tab: 'login') %>" data-auth-signup-url-value="<%= auth_form_path(tab: 'signup') %>" data-auth-tab-value="<%= tab %>">
+<div class="max-w-md mx-auto mt-24 p-8 bg-gray-800 text-gray-100 rounded-xl shadow-lg" data-controller="auth" data-auth-login-url-value="<%= auth_form_path(tab: 'login') %>" data-auth-signup-url-value="<%= auth_form_path(tab: 'signup') %>" data-auth-tab-value="<%= tab %>">
   <div class="flex justify-center gap-4 mb-6">
     <button data-auth-target="loginTab" data-action="auth#showLogin" class="px-3 py-1 rounded <%= 'bg-indigo-600 text-white' if tab != 'signup' %>">Log in</button>
     <button data-auth-target="signupTab" data-action="auth#showSignup" class="px-3 py-1 rounded <%= 'bg-indigo-600 text-white' if tab == 'signup' %>">Sign up</button>


### PR DESCRIPTION
## Summary
- darken login/signup card

## Testing
- `bundle exec rake test` *(fails: version `3.1.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cd789bf7c832a80192a8938389b86