### PR TITLE
Add model validations and tests

### DIFF
--- a/time-tracker/app/models/task.rb
+++ b/time-tracker/app/models/task.rb
@@ -2,6 +2,8 @@ class Task < ApplicationRecord
   belongs_to :user
   has_many :time_entries, dependent: :destroy
 
+  validates :name, presence: true
+
   def running_time_entry
     time_entries.find_by(end_time: nil)
   end

--- a/time-tracker/app/models/time_entry.rb
+++ b/time-tracker/app/models/time_entry.rb
@@ -2,6 +2,19 @@ class TimeEntry < ApplicationRecord
   belongs_to :task
   delegate :user, to: :task
 
+  validates :start_time, presence: true
+  validate :end_time_after_start_time
+
+  private
+
+  def end_time_after_start_time
+    return if end_time.blank?
+
+    if start_time && end_time <= start_time
+      errors.add(:end_time, "must be after start time")
+    end
+  end
+
   def duration
     ((end_time || Time.current) - start_time).to_i
   end

--- a/time-tracker/test/models/task_test.rb
+++ b/time-tracker/test/models/task_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class TaskTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(email: 'user@example.com', password: 'password')
+  end
+
+  test 'name must be present' do
+    task = @user.tasks.build(name: nil)
+    assert_not task.valid?
+    assert_includes task.errors[:name], "can't be blank"
+  end
+end

--- a/time-tracker/test/models/time_entry_test.rb
+++ b/time-tracker/test/models/time_entry_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class TimeEntryTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(email: 'user@example.com', password: 'password')
+    @task = @user.tasks.create!(name: 'Task')
+  end
+
+  test 'start_time must be present' do
+    entry = @task.time_entries.build(start_time: nil)
+    assert_not entry.valid?
+    assert_includes entry.errors[:start_time], "can't be blank"
+  end
+
+  test 'end_time must be after start_time' do
+    entry = @task.time_entries.build(start_time: Time.current, end_time: 1.hour.ago)
+    assert_not entry.valid?
+    assert_includes entry.errors[:end_time], 'must be after start time'
+  end
+
+  test 'valid when end_time is after start_time' do
+    entry = @task.time_entries.build(start_time: Time.current, end_time: 1.hour.from_now)
+    assert entry.valid?
+  end
+
+  test 'requires task association' do
+    entry = TimeEntry.new(start_time: Time.current)
+    assert_not entry.valid?
+    assert_includes entry.errors[:task], 'must exist'
+  end
+end


### PR DESCRIPTION
## Summary
- validate Task name presence
- validate TimeEntry start_time presence and end_time chronology
- add unit tests for Task and TimeEntry validations

## Testing
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_684cdb5cf2e8832a9f5cff1fb5bc543e