### PR TITLE
Add time zone preferences

### DIFF
--- a/time-tracker/app/controllers/application_controller.rb
+++ b/time-tracker/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   helper_method :current_user, :current_running_entry
+  around_action :use_time_zone
 
   private
 
@@ -13,5 +14,10 @@ class ApplicationController < ActionController::Base
 
   def require_login
     redirect_to new_session_path unless current_user
+  end
+
+  def use_time_zone(&block)
+    zone = current_user&.time_zone || 'UTC'
+    Time.use_zone(zone, &block)
   end
 end

--- a/time-tracker/app/controllers/users_controller.rb
+++ b/time-tracker/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :require_login, only: %i[edit update]
+
   def new
     @user = User.new
   end
@@ -13,9 +15,22 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if @user.update(user_params)
+      redirect_to tasks_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation)
+    params.require(:user).permit(:email, :password, :password_confirmation, :time_zone)
   end
 end

--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -19,9 +19,9 @@
       <% @time_entries.each do |entry| %>
         <tr id="time_entry_<%= entry.id %>">
           <td><%= entry.task.name %></td>
-          <td><%= entry.start_time.in_time_zone('Asia/Tokyo').strftime('%A, %B %-d') %></td>
-          <td><%= entry.start_time.in_time_zone('Asia/Tokyo').strftime('%H:%M') %></td>
-          <td><%= entry.end_time&.in_time_zone('Asia/Tokyo')&.strftime('%H:%M') %></td>
+          <td><%= entry.start_time.in_time_zone.strftime('%A, %B %-d') %></td>
+          <td><%= entry.start_time.in_time_zone.strftime('%H:%M') %></td>
+          <td><%= entry.end_time&.in_time_zone&.strftime('%H:%M') %></td>
           <td><%= Time.at(entry.duration).utc.strftime('%H:%M:%S') %></td>
           <td><%= entry.comment %></td>
           <td>

--- a/time-tracker/app/views/layouts/application.html.erb
+++ b/time-tracker/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
         <nav class="sm:ml-auto mt-2 sm:mt-0">
           <%= link_to 'Work Hours', calendar_path %> |
           <%= link_to 'Tasks', tasks_path %> |
+          <%= link_to 'Profile', edit_user_path(current_user) %> |
           <%= link_to 'Logout', session_path, data: { turbo_method: :delete } %>
         </nav>
       <% end %>

--- a/time-tracker/app/views/users/_form.html.erb
+++ b/time-tracker/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: user, url: users_path, data: { turbo_frame: "_top" } do |f| %>
+<%= form_with model: user, data: { turbo_frame: "_top" } do |f| %>
   <div class="mb-4">
     <%= f.label :email, class: 'block mb-1' %>
     <%= f.email_field :email, class: 'w-full' %>
@@ -11,5 +11,13 @@
     <%= f.label :password_confirmation, class: 'block mb-1' %>
     <%= f.password_field :password_confirmation, class: 'w-full' %>
   </div>
-  <%= f.submit 'Sign up', class: 'w-full bg-blue-600 text-white rounded py-2' %>
+  <div class="mb-4">
+    <%= f.label :time_zone, class: 'block mb-1' %>
+    <%= f.select :time_zone,
+                 ActiveSupport::TimeZone.all.map { |tz| [tz.name, tz.name] },
+                 {},
+                 class: 'w-full' %>
+  </div>
+  <%= f.submit user.persisted? ? 'Update' : 'Sign up',
+               class: 'w-full bg-blue-600 text-white rounded py-2' %>
 <% end %>

--- a/time-tracker/app/views/users/edit.html.erb
+++ b/time-tracker/app/views/users/edit.html.erb
@@ -1,0 +1,7 @@
+<div class="max-w-md mx-auto mt-10 p-6 bg-gray-800 rounded text-white">
+  <h1 class="text-2xl mb-4 text-center">Edit Profile</h1>
+  <%= render 'users/form', user: @user %>
+  <div class="mt-4 text-center">
+    <%= link_to 'Back', tasks_path %>
+  </div>
+</div>

--- a/time-tracker/config/application.rb
+++ b/time-tracker/config/application.rb
@@ -21,8 +21,8 @@ module TimeTracker
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    config.time_zone = "Asia/Tokyo"
-    config.active_record.default_timezone = :local
+    config.time_zone = "UTC"
+    config.active_record.default_timezone = :utc
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/time-tracker/config/routes.rb
+++ b/time-tracker/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   resource :session, only: %i[create destroy]
-  resources :users, only: %i[create]
+  resources :users, only: %i[create edit update]
 
   get 'session/new', to: 'auth#new', defaults: { tab: 'login' }, as: :new_session
   get 'users/new', to: 'auth#new', defaults: { tab: 'signup' }, as: :new_user

--- a/time-tracker/db/migrate/20240101000005_add_time_zone_to_users.rb
+++ b/time-tracker/db/migrate/20240101000005_add_time_zone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :time_zone, :string, default: 'UTC', null: false
+  end
+end


### PR DESCRIPTION
## Summary
- allow users to choose a time zone
- fall back to user time zone for formatting
- provide profile editing

## Testing
- `bin/rails db:migrate RAILS_ENV=test`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_684cdb5f5a14832a91539239ac679d11