### PR TITLE
Fix calendar duration error

### DIFF
--- a/time-tracker/app/models/time_entry.rb
+++ b/time-tracker/app/models/time_entry.rb
@@ -5,6 +5,10 @@ class TimeEntry < ApplicationRecord
   validates :start_time, presence: true
   validate :end_time_after_start_time
 
+  def duration
+    ((end_time || Time.current) - start_time).to_i
+  end
+
   private
 
   def end_time_after_start_time
@@ -15,7 +19,4 @@ class TimeEntry < ApplicationRecord
     end
   end
 
-  def duration
-    ((end_time || Time.current) - start_time).to_i
-  end
 end


### PR DESCRIPTION
## Summary
- make TimeEntry#duration a public method so views can access it

## Testing
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_684ce03672e8832a8ac32ddc387eb86c