### PR TITLE
Fix modal dark mode

### DIFF
--- a/time-tracker/app/views/calendar/show.html.erb
+++ b/time-tracker/app/views/calendar/show.html.erb
@@ -46,14 +46,14 @@
 </div>
 <div
   id="delete-modal"
-  class="fixed inset-0 flex items-center justify-center bg-black/60 z-50 hidden"
+  class="fixed inset-0 flex items-center justify-center bg-black/60 dark:bg-black/80 z-50 hidden"
   data-delete-target="modal"
 >
-  <div class="bg-white rounded-lg p-6 max-w-sm w-full">
-    <p class="text-lg text-center mb-4">Are you sure you want to delete this entry?</p>
+  <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-sm w-full">
+    <p class="text-lg text-center mb-4 text-gray-900 dark:text-white">Are you sure you want to delete this entry?</p>
     <div class="flex justify-around">
       <button class="bg-red-600 text-white px-4 py-2 rounded" data-action="click->delete#submit">Yes</button>
-      <button class="bg-gray-300 px-4 py-2 rounded" data-action="click->delete#cancel">No</button>
+      <button class="bg-gray-300 dark:bg-gray-600 text-black dark:text-white px-4 py-2 rounded" data-action="click->delete#cancel">No</button>
     </div>
   </div>
 </div>

--- a/time-tracker/app/views/shared/_task_picker.html.erb
+++ b/time-tracker/app/views/shared/_task_picker.html.erb
@@ -1,8 +1,8 @@
 <div id="task-picker"
      data-controller="picker"
-     class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-  <div class="bg-white p-6 rounded-xl w-full max-w-sm">
-    <h2 class="text-lg font-semibold mb-4 text-center">What are you working on?</h2>
+     class="hidden fixed inset-0 bg-black/50 dark:bg-black/80 flex items-center justify-center z-50">
+  <div class="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
+    <h2 class="text-lg font-semibold mb-4 text-center text-gray-900 dark:text-white">What are you working on?</h2>
     <select data-picker-target="task" class="w-full mb-4">
       <option value="">-- choose --</option>
       <% Task.order(:name).each { |t| %>


### PR DESCRIPTION
## Summary
- update task picker modal for dark mode
- tweak delete modal on calendar page for dark mode

## Testing
- `bundle exec rails test` *(fails: rbenv version `3.1.2` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ce3f44cbc832a82ddcaeb3b9ef23f