### PR TITLE
Add not-null constraint for tasks name

### DIFF
--- a/time-tracker/Gemfile
+++ b/time-tracker/Gemfile
@@ -36,7 +36,7 @@ gem "jbuilder"
 gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms: %i[ mswin mingw x64_mingw jruby ]
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -46,7 +46,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ]
+  gem "debug", platforms: %i[ mri mswin mingw x64_mingw ]
 end
 
 group :development do

--- a/time-tracker/db/migrate/20240101000006_add_not_null_to_tasks_name.rb
+++ b/time-tracker/db/migrate/20240101000006_add_not_null_to_tasks_name.rb
@@ -1,0 +1,11 @@
+class AddNotNullToTasksName < ActiveRecord::Migration[7.1]
+  def up
+    # Ensure all existing tasks have a name before adding NOT NULL constraint
+    Task.where(name: [nil, ""]).update_all(name: "Unnamed Task")
+    change_column_null :tasks, :name, false
+  end
+
+  def down
+    change_column_null :tasks, :name, true
+  end
+end

--- a/time-tracker/db/schema.rb
+++ b/time-tracker/db/schema.rb
@@ -1,0 +1,44 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2024_01_01_000006) do
+  create_table "tasks", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_tasks_on_user_id"
+  end
+
+  create_table "time_entries", force: :cascade do |t|
+    t.integer "task_id", null: false
+    t.datetime "start_time", null: false
+    t.datetime "end_time"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "comment"
+    t.index ["task_id"], name: "index_time_entries_on_task_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "time_zone", default: "UTC", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "tasks", "users"
+  add_foreign_key "time_entries", "tasks"
+end


### PR DESCRIPTION
## Summary
- enforce non-null names for tasks
- update Gemfile platform symbols so bundle install works
- update schema with new constraint

## Testing
- `bundle exec rake test`
- `bin/rails db:migrate`


------
https://chatgpt.com/codex/tasks/task_e_684ce70e1c34832a91286fee29b2851c