### PR TITLE
Improve timezone selection

### DIFF
--- a/time-tracker/app/javascript/controllers/timezone_controller.js
+++ b/time-tracker/app/javascript/controllers/timezone_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    try {
+      const zone = Intl.DateTimeFormat().resolvedOptions().timeZone
+      const option = this.element.querySelector(`option[value="${zone}"]`)
+      if (option) {
+        this.element.value = zone
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
+}

--- a/time-tracker/app/views/users/_form.html.erb
+++ b/time-tracker/app/views/users/_form.html.erb
@@ -16,7 +16,7 @@
     <%= f.select :time_zone,
                  ActiveSupport::TimeZone.all.map { |tz| [tz.name, tz.name] },
                  {},
-                 class: 'w-full' %>
+                 { class: 'w-full', data: { controller: 'timezone' } } %>
   </div>
   <%= f.submit user.persisted? ? 'Update' : 'Sign up',
                class: 'w-full bg-blue-600 text-white rounded py-2' %>


### PR DESCRIPTION
## Summary
- auto-select browser timezone on sign-up

## Testing
- `bin/rails test` *(fails: Ruby 3.1.2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ce8035e14832a8084fab99765667c