### PR TITLE
Add close button to task picker modal

### DIFF
--- a/time-tracker/app/javascript/controllers/picker_controller.js
+++ b/time-tracker/app/javascript/controllers/picker_controller.js
@@ -4,6 +4,10 @@ import { csrfToken } from "../csrf"
 export default class extends Controller {
   static targets = ["task"]
 
+  cancel() {
+    this.element.classList.add('hidden')
+  }
+
   confirm() {
     const taskId = this.taskTarget.value
     if (!taskId) return

--- a/time-tracker/app/views/shared/_task_picker.html.erb
+++ b/time-tracker/app/views/shared/_task_picker.html.erb
@@ -1,7 +1,10 @@
 <div id="task-picker"
      data-controller="picker"
      class="hidden fixed inset-0 bg-black/50 dark:bg-black/80 flex items-center justify-center z-50">
-  <div class="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
+  <div class="relative bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
+    <button class="absolute top-2 right-2 text-gray-500 hover:text-gray-700" data-action="picker#cancel">
+      <i class="fa fa-times"></i>
+    </button>
     <h2 class="text-lg font-semibold mb-4 text-center text-gray-900 dark:text-white">What are you working on?</h2>
     <select data-picker-target="task" class="w-full mb-4">
       <option value="">-- choose --</option>


### PR DESCRIPTION
## Summary
- allow dismissing the task picker modal without starting a timer

## Testing
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_684ceecc5c78832aaa103613c1b083c9