### PR TITLE
Add task delete actions

### DIFF
--- a/time-tracker/app/controllers/tasks_controller.rb
+++ b/time-tracker/app/controllers/tasks_controller.rb
@@ -32,7 +32,10 @@ class TasksController < ApplicationController
 
   def destroy
     @task.destroy
-    redirect_to tasks_path, notice: "Task deleted."
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to tasks_path, notice: "Task deleted." }
+    end
   end
 
   private

--- a/time-tracker/app/javascript/controllers/task_delete_controller.js
+++ b/time-tracker/app/javascript/controllers/task_delete_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
+import { csrfToken } from "../csrf"
+
+export default class extends Controller {
+  static values = { id: Number }
+  static targets = ["modal"]
+
+  confirm(event) {
+    this.idValue = event.currentTarget.dataset.taskDeleteIdValue
+    this.modalTarget.classList.remove("hidden")
+  }
+
+  cancel() {
+    this.modalTarget.classList.add("hidden")
+  }
+
+  submit() {
+    fetch(`/tasks/${this.idValue}`, {
+      method: "DELETE",
+      headers: {
+        "Accept": "text/vnd.turbo-stream.html",
+        "X-CSRF-Token": csrfToken()
+      }
+    })
+      .then(response => response.text())
+      .then(html => Turbo.renderStreamMessage(html))
+      .then(() => this.cancel())
+  }
+}

--- a/time-tracker/app/views/shared/_delete_modal.html.erb
+++ b/time-tracker/app/views/shared/_delete_modal.html.erb
@@ -1,15 +1,15 @@
-<div id="delete-modal" data-modal-target="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 dark:bg-black/80 z-50 hidden">
+<div id="delete-modal" data-task-delete-target="modal" class="fixed inset-0 flex items-center justify-center bg-black/60 dark:bg-black/80 z-50 hidden">
   <div class="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-sm">
     <p class="mb-4 text-lg text-center text-gray-900 dark:text-white">
       Are you sure you want to delete this record?
     </p>
     <div class="flex justify-around">
       <button
-        data-action="modal#confirm"
+        data-action="task-delete#submit"
         class="px-4 py-2 bg-red-600 text-white rounded-md"
       >Yes</button>
       <button
-        data-action="modal#close"
+        data-action="task-delete#cancel"
         class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-black dark:text-white rounded-md"
       >No</button>
     </div>

--- a/time-tracker/app/views/tasks/destroy.turbo_stream.erb
+++ b/time-tracker/app/views/tasks/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "task_#{@task.id}" %>

--- a/time-tracker/app/views/tasks/index.html.erb
+++ b/time-tracker/app/views/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="modal">
+<div data-controller="task-delete">
 <div class="max-w-3xl mx-auto mt-8">
   <div data-controller="time-tracker" data-time-tracker-start="<%= current_running_entry&.start_time&.iso8601 %>" data-time-tracker-entry-id="<%= current_running_entry&.id %>" class="max-w-md mx-auto p-4 bg-gray-800 rounded text-white">
   <% if current_running_entry %>
@@ -30,14 +30,14 @@
   </thead>
   <tbody>
     <% @tasks.each do |task| %>
-      <tr>
+      <tr id="task_<%= task.id %>">
         <td><%= link_to task.name, calendar_path(task_id: task.id) %></td>
         <td><%= task.description %></td>
         <td>
           <%= link_to edit_task_path(task), class: 'icon-button', title: 'Edit' do %>
             <i class="fa fa-pen"></i>
           <% end %>
-          <button class="icon-button" data-action="modal#open" data-modal-id-value="<%= task.id %>">
+          <button class="icon-button" data-action="task-delete#confirm" data-task-delete-id-value="<%= task.id %>">
             <i class="fa fa-trash"></i>
           </button>
         </td>


### PR DESCRIPTION
## Summary
- add `task-delete` Stimulus controller
- support Turbo stream deletion for tasks
- hook up delete buttons on tasks page

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684cef09b900832a8274b844c1eb5634