### PR TITLE
Add labels for task action buttons

### DIFF
--- a/time-tracker/app/views/tasks/index.html.erb
+++ b/time-tracker/app/views/tasks/index.html.erb
@@ -35,10 +35,10 @@
         <td><%= task.description %></td>
         <td>
           <%= link_to edit_task_path(task), class: 'icon-button', title: 'Edit' do %>
-            <i class="fa fa-pen"></i>
+            <i class="fa fa-pen"></i> Edit
           <% end %>
           <button class="icon-button" data-action="task-delete#confirm" data-task-delete-id-value="<%= task.id %>">
-            <i class="fa fa-trash"></i>
+            <i class="fa fa-trash"></i> Delete
           </button>
         </td>
       </tr>


### PR DESCRIPTION
## Summary
- add `Edit` and `Delete` text next to the edit and delete icons so the buttons are visible

## Testing
- `bundle exec rails test --verbose`

------
https://chatgpt.com/codex/tasks/task_e_684cf1e4a380832a8b8ceaa68c3e5981