### PR TITLE
Fix header timer data access

### DIFF
--- a/time-tracker/app/javascript/controllers/header_timer_controller.js
+++ b/time-tracker/app/javascript/controllers/header_timer_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
 
   start(event) {
     event.preventDefault()
-    const taskId = this.data.get("taskId")
+    const taskId = this.element.dataset.taskId
     if (!taskId) {
       const modal = document.getElementById('task-picker')
       if (modal) modal.classList.remove('hidden')
@@ -27,7 +27,7 @@ export default class extends Controller {
         'X-CSRF-Token': csrfToken()
       }
     }).then(r => r.json()).then(data => {
-      this.data.set("entryId", data.id)
+      this.element.dataset.entryId = data.id
       const timer = document.getElementById('timer')
       if (timer) timer.dataset.start = data.start_time
       this.showStop()
@@ -36,8 +36,8 @@ export default class extends Controller {
 
   stop(event) {
     event.preventDefault()
-    const taskId = this.data.get("taskId")
-    const entryId = this.data.get("entryId")
+    const taskId = this.element.dataset.taskId
+    const entryId = this.element.dataset.entryId
     if (!taskId || !entryId) return
     fetch(`/tasks/${taskId}/time_entries/${entryId}`, {
       method: 'PUT',
@@ -49,14 +49,14 @@ export default class extends Controller {
     }).then(() => {
       const timer = document.getElementById('timer')
       if (timer) timer.dataset.start = ''
-      this.data.delete("entryId")
+      delete this.element.dataset.entryId
       this.showStart()
       showToast("Hours logged")
     })
   }
 
   updateButtons() {
-    if (this.data.get("entryId")) {
+    if (this.element.dataset.entryId) {
       this.showStop()
     } else {
       this.showStart()


### PR DESCRIPTION
## Summary
- fix header timer data attributes to match dataset

## Testing
- `bundle exec rake test` *(fails: Could not find rails-7.1.5.1, sprockets-rails-3.5.2, sqlite3-2.7.0-x86_64-linux-gnu, puma-6.6.0, importmap-rails-2.1.0, turbo-rails-2.0.16, stimulus-rails-1.3.4, jbuilder-2.13.0, bcrypt-3.1.20, bootsnap-1.18.6, debug-1.10.0, web-console-4.2.1, error_highlight-0.7.0, capybara-3.40.0, selenium-webdriver-4.32.0, actioncable-7.1.5.1, actionmailbox-7.1.5.1, actionmailer-7.1.5.1, actionpack-7.1.5.1, actiontext-7.1.5.1, actionview-7.1.5.1, activejob-7.1.5.1, activemodel-7.1.5.1, activerecord-7.1.5.1, activestorage-7.1.5.1, activesupport-7.1.5.1, railties-7.1.5.1, sprockets-4.2.2, nio4r-2.7.4, msgpack-1.8.0, irb-1.15.2, reline-0.6.1, ...)*

------
https://chatgpt.com/codex/tasks/task_e_684cf495cdd4832ab460868202e80824